### PR TITLE
Add installation method for phar archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Requirements
 Attributes
 ==========
 
-* `node['phploc']['install_method']` - Installation method, "pear" or "composer", defaults to "pear"
+* `node['phploc']['install_method']` - Installation method, "pear", "composer" or "phar", defaults to "pear"
 * `node['phploc']['version']` - The phploc version that will be installed, defaults to "latest"
 * `node['phploc']['prefix']` - The composer.json bin-dir, defaults to "/usr/bin" (composer install method only)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,3 +10,7 @@ default[:phploc][:version] = "latest"
 
 #composer install only
 default[:phploc][:prefix] = "/usr/bin"
+
+#phar install only
+default[:phploc][:phar_url] = "http://pear.phpunit.de/get/phploc.phar"
+default[:phploc][:install_dir] = ""

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -10,4 +10,6 @@ case node[:phploc][:install_method]
 		include_recipe "phploc::pear"
 	when "composer"
 		include_recipe "phploc::composer"
+	when "phar"
+		include_recipe "phploc::phar"
 end

--- a/recipes/phar.rb
+++ b/recipes/phar.rb
@@ -1,0 +1,24 @@
+#
+# Cookbook Name:: phploc
+# Recipe:: phar
+#
+# Copyright 2013, Escape Studios
+#
+
+if node[:phploc][:install_dir] != ""
+	phploc_dir = node[:phploc][:install_dir]
+else
+	phploc_dir = "#{Chef::Config[:file_cache_path]}/phploc"
+end
+
+directory "#{phploc_dir}" do
+	owner "root"
+	group "root"
+	mode "0755"
+	action :create
+end
+
+remote_file "#{phploc_dir}/phploc.phar" do
+	source node[:phploc][:phar_url]
+	mode "0755"
+end


### PR DESCRIPTION
At the moment the composer install of phploc is broken, because the defined symfony/finder version is not available at packagist.
And personally i don`t like PEAR very much.

It is possible to install phploc as a PHAR archive.
In this PR i`ve added the PHAR install method to this cookbook recipe.
