### PR TITLE
Refactor for configurable install location

### DIFF
--- a/attributes/composer.rb
+++ b/attributes/composer.rb
@@ -5,4 +5,4 @@
 # Copyright (c) 2016, David Joos
 #
 
-default['phploc']['prefix'] = '/usr/bin'
+default['phploc']['install_dir'] = '/usr/local/phploc'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,3 +7,4 @@
 
 default['phploc']['install_method'] = 'composer'
 default['phploc']['version'] = 'latest'
+default['phploc']['bin_dir'] = '/usr/bin'

--- a/attributes/phar.rb
+++ b/attributes/phar.rb
@@ -5,5 +5,4 @@
 # Copyright (c) 2016, David Joos
 #
 
-default['phploc']['phar_url'] = 'https://phar.phpunit.de/phploc.phar'
-default['phploc']['install_dir'] = '/usr/bin'
+default['phploc']['phar_url'] = 'https://phar.phpunit.de/phpunit.phar'

--- a/recipes/composer.rb
+++ b/recipes/composer.rb
@@ -7,7 +7,7 @@
 
 include_recipe 'composer'
 
-phploc_dir = "#{Chef::Config[:file_cache_path]}/phploc"
+phploc_dir = node['phploc']['install_dir']
 
 directory phploc_dir do
   owner 'root'
@@ -31,7 +31,7 @@ template "#{phploc_dir}/composer.json" do
   mode 0600
   variables(
     :version => version,
-    :bindir => node['phploc']['prefix']
+    :bindir => node['phploc']['bin_dir']
   )
 end
 

--- a/recipes/phar.rb
+++ b/recipes/phar.rb
@@ -5,6 +5,8 @@
 # Copyright (c) 2016, David Joos
 #
 
+include_recipe 'php'
+
 remote_file "#{node['phploc']['bin_dir']}/phploc" do
   source node['phploc']['phar_url']
   mode 0755

--- a/recipes/phar.rb
+++ b/recipes/phar.rb
@@ -5,7 +5,7 @@
 # Copyright (c) 2016, David Joos
 #
 
-remote_file "#{node['phploc']['install_dir']}/phploc" do
+remote_file "#{node['phploc']['bin_dir']}/phploc" do
   source node['phploc']['phar_url']
   mode 0755
 end


### PR DESCRIPTION
I've refactored this too for a configurable install location (for composer).

In relation, I'm wondering about the separate attribute files. There is a default and one per recipe. But in chef (unlike ansible) the recipes don't load the corresponding attribute file. All attribute files are loaded in a certain order. I think by default alphabetically, but the order can be set in metadata.rb. But for the use cases for these cookbooks, I don't see the advantages, I'd put all attributes in the default.rb file and make separate sections.
See also http://docs.chef.io/attributes.html
